### PR TITLE
Adding checks for a release tag on the consul images.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "vnet" {
 }
 
 module "waf" {
-  source            = "git::git@github.com:contino/moj-module-waf?ref=fixing-minProtocolVersion"
+  source            = "git::git@github.com:contino/moj-module-waf?ref=master"
   product           = "${var.name}"
   location          = "${var.location}"
   env               = "${var.env}"


### PR DESCRIPTION
As we are creating more and more consul imagesI have added in a check to see if any images are tagged with the pair - version:release.

The script will collate a list of these images with a tag and use the latest one. If a tagged image isn't found, it will just default to the latest one, ensuring this is not a breaking change.