### PR TITLE
Fixes issue with wrong ip range being applied

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,5 +53,5 @@ module "api-mgmt" {
   vnet_rg_name       = "${module.vnet.resourcegroup_name}"
   vnet_name          = "${module.vnet.vnetname}"
   source_range       = "${cidrsubnet("${var.root_address_space}", 6, "${var.netnum}")}"
-  source_range_index = "${length(module.vnet.subnet_ids)}"
+  source_range_index = "${length(module.vnet.subnet_ids) + 1}"
 }


### PR DESCRIPTION
API Management is currently trying to create a subnet inthe wrong ip
range

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
