### PR TITLE
Add named value to the core-api-mgmt

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "vnet" {
 }
 
 module "api-mgmt" {
-  source               = "git@github.com:hmcts/cnp-module-api-mgmt?ref=master"
+  source               = "git@github.com:hmcts/cnp-module-api-mgmt?ref=u878-api_mgmt_tf"
   location             = var.location
   env                  = var.env
   vnet_rg_name         = module.vnet.resourcegroup_name

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "vnet" {
 }
 
 module "api-mgmt" {
-  source               = "git@github.com:hmcts/cnp-module-api-mgmt?ref=u878-api_mgmt_tf"
+  source               = "git@github.com:hmcts/cnp-module-api-mgmt?ref=master"
   location             = var.location
   env                  = var.env
   vnet_rg_name         = module.vnet.resourcegroup_name

--- a/main.tf
+++ b/main.tf
@@ -27,3 +27,11 @@ module "api-mgmt" {
   source_range_index   = length(module.vnet.subnet_ids)
   virtual_network_type = var.virtual_network_type
 }
+
+resource "azurerm_api_management_named_value" "environment-named-value" {
+  name                = "environment"
+  resource_group_name = module.vnet.resourcegroup_name
+  api_management_name = module.api-mgmt.api_mgmt_name
+  display_name        = "environment"
+  value               = "${var.env}"
+}


### PR DESCRIPTION
Adds a `NamedValue` in `core-api-mgmt` which is used in [api-policy.xml file ](https://github.com/hmcts/blob-router-service/blob/master/infrastructure/api-policy-v2.xml#L28).
