### PR TITLE
Removing module and resource block for APIM services off the back of DTSPO-18907.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,23 +26,3 @@ module "vnet" {
   common_tags = module.ctags.common_tags
 }
 
-module "api-mgmt" {
-  source               = "git@github.com:hmcts/cnp-module-api-mgmt?ref=master"
-  location             = var.location
-  env                  = var.env
-  vnet_rg_name         = module.vnet.resourcegroup_name
-  vnet_name            = module.vnet.vnetname
-  source_range         = var.address_space
-  source_range_index   = length(module.vnet.subnet_ids)
-  virtual_network_type = var.virtual_network_type
-
-  common_tags = module.ctags.common_tags
-}
-
-resource "azurerm_api_management_named_value" "environment-named-value" {
-  name                = "environment"
-  resource_group_name = module.vnet.resourcegroup_name
-  api_management_name = module.api-mgmt.api_mgmt_name
-  display_name        = "environment"
-  value               = var.env
-}


### PR DESCRIPTION
Notes:
https://tools.hmcts.net/jira/browse/DTSPO-18907

Removing module and resource block that are related to the Core-api-mgmt-* resources after manual deletion through the azure portal. 
